### PR TITLE
Timeout fixes

### DIFF
--- a/bsw/bsw.go
+++ b/bsw/bsw.go
@@ -12,7 +12,7 @@ var DomainRegex = `^\.?[a-z\d]+(?:(?:[a-z\d]*)|(?:[a-z\d\-]*[a-z\d]))(?:\.[a-z\d
 type Tsk struct {
 	task    string
 	results []Result
-	err     error
+	errs    []error
 }
 
 func newTsk(task string) *Tsk {
@@ -44,13 +44,13 @@ func (t *Tsk) HasResults() bool {
 }
 
 // Err returns the value of err.
-func (t *Tsk) Err() error {
-	return t.err
+func (t *Tsk) Err() []error {
+	return t.errs
 }
 
 // SetErr sets the value of err
 func (t *Tsk) SetErr(err error) {
-	t.err = err
+	t.errs = append(t.errs, err)
 }
 
 // Results returns the results.

--- a/bsw/header.go
+++ b/bsw/header.go
@@ -18,7 +18,6 @@ func Headers(ip string, timeout int64) *Tsk {
 		host, err := hostnameFromHTTPLocationHeader(ip, proto, timeout)
 		if err != nil {
 			t.SetErr(err)
-			return t
 		} else if host != "" {
 			t.AddResult(ip, host)
 		}
@@ -34,7 +33,12 @@ func hostnameFromHTTPLocationHeader(ip, protocol string, timeout int64) (string,
 	}
 	tr := &http.Transport{
 		Dial: func(network, addr string) (net.Conn, error) {
-			return net.DialTimeout(network, addr, time.Duration(timeout)*time.Millisecond)
+			conn, err := net.DialTimeout(network, addr, time.Duration(timeout)*time.Millisecond)
+			if err != nil {
+				return nil, err
+			}
+			conn.SetDeadline(time.Now().Add(time.Duration(timeout) * time.Millisecond))
+			return conn, nil
 		},
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}


### PR DESCRIPTION
Added SetDeadline and now connections don't hang.
Converted task error to an array of errors.
removed the return in the headers function, it wasn't testing 443 if 80
threw an error.