### PR TITLE
RFC: Improve handling of multiple IPs and wildcard records

### DIFF
--- a/bsw/axfr.go
+++ b/bsw/axfr.go
@@ -39,24 +39,24 @@ func AXFR(domain, serverAddr string) *Tsk {
 					hostname = v.Ptr
 				case *dns.NS:
 					cip, err := LookupName(v.Ns, serverAddr)
-					if err != nil || cip == "" {
+					if err != nil || len(cip) == 0 {
 						continue
 					}
-					ip = cip
+					ip = cip[0]
 					hostname = v.Ns
 				case *dns.CNAME:
 					cip, err := LookupName(v.Target, serverAddr)
-					if err != nil || cip == "" {
+					if err != nil || len(cip) == 0 {
 						continue
 					}
 					hostname = v.Hdr.Name
-					ip = cip
+					ip = cip[0]
 				case *dns.SRV:
 					cip, err := LookupName(v.Target, serverAddr)
-					if err != nil || ip == "" {
+					if err != nil || len(cip) == 0 {
 						continue
 					}
-					ip = cip
+					ip = cip[0]
 					hostname = v.Target
 				default:
 					continue

--- a/bsw/bing.go
+++ b/bsw/bing.go
@@ -126,18 +126,20 @@ func BingAPIDomain(domain, key, path, server string) *Tsk {
 		if err != nil || u.Host == "" {
 			continue
 		}
-		ip, err := LookupName(u.Host, server)
-		if err != nil || ip == "" {
+		ips, err := LookupName(u.Host, server)
+		if err != nil || len(ips) == 0 {
 			cfqdn, err := LookupCname(u.Host, server)
 			if err != nil || cfqdn == "" {
 				continue
 			}
-			ip, err = LookupName(cfqdn, server)
-			if err != nil || ip == "" {
+			ips, err = LookupName(cfqdn, server)
+			if err != nil || len(ips) == 0 {
 				continue
 			}
 		}
-		t.AddResult(ip, u.Host)
+		for _, ip := range ips {
+			t.AddResult(ip, u.Host)
+		}
 	}
 	return t
 }
@@ -183,19 +185,21 @@ func BingDomain(domain, server string) *Tsk {
 		if err != nil || u.Host == "" {
 			return
 		}
-		ip, err := LookupName(u.Host, server)
-		if err != nil || ip == "" {
+		ips, err := LookupName(u.Host, server)
+		if err != nil || len(ips) == 0 {
 			cfqdn, err := LookupCname(u.Host, server)
 			if err != nil || cfqdn == "" {
 				return
 			}
-			ip, err = LookupName(cfqdn, server)
-			if err != nil || ip == "" {
+			ips, err = LookupName(cfqdn, server)
+			if err != nil || len(ips) == 0 {
 				return
 			}
 
 		}
-		t.AddResult(ip, u.Host)
+		for _, ip := range ips {
+			t.AddResult(ip, u.Host)
+		}
 	})
 	return t
 }

--- a/bsw/common_crawl.go
+++ b/bsw/common_crawl.go
@@ -51,7 +51,7 @@ func CommonCrawl(domain, path, serverAddr string) *Tsk {
 		wg.Add(1)
 		go func(sub string) {
 			defer wg.Done()
-			xtsk := Dictionary(domain, sub, "", serverAddr)
+			xtsk := Dictionary(domain, sub, nil, serverAddr)
 			if len(xtsk.Err()) > 0 {
 				return
 			}

--- a/bsw/dictionary.go
+++ b/bsw/dictionary.go
@@ -1,36 +1,39 @@
 package bsw
 
 import "fmt"
+import "reflect"
 
 const wildcardsub = "youmustcontstuctmoreplyons."
 
 // GetWildCard searches for a possible wild card host by attempting to
-// get an A record for wildcardsub + domain.
-func GetWildCard(domain, serverAddr string) string {
+// get A records for wildcardsub + domain.
+func GetWildCards(domain, serverAddr string) []string {
 	fqdn := wildcardsub + domain
-	ip, _ := LookupName(fqdn, serverAddr)
-	return ip
+	ips, _ := LookupName(fqdn, serverAddr)
+	return ips
 }
 
 // GetWildCard6 searches for a possible wild card host by attempting to
-// get an AAAA record wildcardsub + domain.
-func GetWildCard6(domain, serverAddr string) string {
+// get AAAA records wildcardsub + domain.
+func GetWildCards6(domain, serverAddr string) []string {
 	fqdn := wildcardsub + domain
-	ip, _ := LookupName6(fqdn, serverAddr)
-	return ip
+	ips, _ := LookupName6(fqdn, serverAddr)
+	return ips
 }
 
 // Dictionary attempts to get an A and CNAME record for a sub domain of domain.
-func Dictionary(domain, subname, blacklist, serverAddr string) *Tsk {
+func Dictionary(domain string, subname string, blacklist []string, serverAddr string) *Tsk {
 	t := newTsk("Dictionary IPv4")
 	fqdn := subname + "." + domain
-	ip, err := LookupName(fqdn, serverAddr)
+	ips, err := LookupName(fqdn, serverAddr)
 	if err == nil {
-		if ip == blacklist {
-			t.SetErr(fmt.Errorf("%v: returned IP in blackslist", ip))
+		if reflect.DeepEqual(ips, blacklist) {
+			t.SetErr(fmt.Errorf("%v: returned IPs in blackslist", ips))
 			return t
 		}
-		t.AddResult(ip, fqdn)
+		for _, ip := range ips {
+			t.AddResult(ip, fqdn)
+		}
 		return t
 	}
 
@@ -46,7 +49,7 @@ func Dictionary(domain, subname, blacklist, serverAddr string) *Tsk {
 			return t
 		}
 		cfqdns = append(cfqdns, cfqdn)
-		ip, err = LookupName(cfqdn, serverAddr)
+		ips, err = LookupName(cfqdn, serverAddr)
 		if err != nil {
 			ecount++
 			if ecount > 10 {
@@ -59,31 +62,35 @@ func Dictionary(domain, subname, blacklist, serverAddr string) *Tsk {
 		break
 	}
 
-	if ip == blacklist {
-		t.SetErr(fmt.Errorf("%v: returned IP in blackslist", ip))
+	if reflect.DeepEqual(ips, blacklist) {
+		t.SetErr(fmt.Errorf("%v: returned IPs in blackslist", ips))
 		return t
 	}
 	t.SetTask("Dictionary-CNAME")
-	t.AddResult(ip, fqdn)
-	for _, c := range cfqdns {
-		t.AddResult(ip, c)
+	for _, ip := range ips {
+		t.AddResult(ip, fqdn)
+		for _, c := range cfqdns {
+			t.AddResult(ip, c)
+		}
 	}
 	return t
 }
 
 // Dictionary6 attempts to get an AAAA record for a sub domain of a domain.
-func Dictionary6(domain, subname, blacklist, serverAddr string) *Tsk {
+func Dictionary6(domain string, subname string, blacklist []string, serverAddr string) *Tsk {
 	t := newTsk("Dictionary IPv6")
 	fqdn := subname + "." + domain
-	ip, err := LookupName6(fqdn, serverAddr)
+	ips, err := LookupName6(fqdn, serverAddr)
 	if err != nil {
 		t.SetErr(err)
 		return t
 	}
-	if ip == blacklist {
-		t.SetErr(fmt.Errorf("%v: returned IP in blacklist", ip))
+	if reflect.DeepEqual(ips, blacklist) {
+		t.SetErr(fmt.Errorf("%v: returned IPs in blacklist", ips))
 		return t
 	}
-	t.AddResult(ip, fqdn)
+	for _, ip := range ips {
+		t.AddResult(ip, fqdn)
+	}
 	return t
 }

--- a/bsw/exfiltrated.go
+++ b/bsw/exfiltrated.go
@@ -30,19 +30,21 @@ func ExfiltratedHostname(domain, server string) *Tsk {
 		wg.Add(1)
 		go func(hostname string) {
 			defer wg.Done()
-			ip, err := LookupName(hostname, server)
-			if err != nil || ip == "" {
+			ips, err := LookupName(hostname, server)
+			if err != nil || len(ips) == 0 {
 				cfqdn, err := LookupCname(hostname, server)
 				if err != nil || cfqdn == "" {
 					return
 				}
-				ip, err = LookupName(cfqdn, server)
-				if err != nil || ip == "" {
+				ips, err = LookupName(cfqdn, server)
+				if err != nil || len(ips) == 0 {
 					return
 				}
 			}
 			mutex.Lock()
-			t.AddResult(ip, hostname)
+			for _, ip := range ips {
+				t.AddResult(ip, hostname)
+			}
 			mutex.Unlock()
 		}(s.Text())
 	})

--- a/bsw/mx.go
+++ b/bsw/mx.go
@@ -13,11 +13,13 @@ func MX(domain, serverAddr string) *Tsk {
 		return t
 	}
 	for _, s := range servers {
-		ip, err := LookupName(s, serverAddr)
-		if err != nil || ip == "" {
+		ips, err := LookupName(s, serverAddr)
+		if err != nil || len(ips) == 0 {
 			continue
 		}
-		t.AddResult(ip, strings.TrimRight(s, "."))
+		for _, ip := range ips {
+			t.AddResult(ip, strings.TrimRight(s, "."))
+		}
 	}
 	return t
 }

--- a/bsw/ns.go
+++ b/bsw/ns.go
@@ -13,11 +13,13 @@ func NS(domain, serverAddr string) *Tsk {
 		return t
 	}
 	for _, s := range servers {
-		ip, err := LookupName(s, serverAddr)
-		if err != nil || ip == "" {
+		ips, err := LookupName(s, serverAddr)
+		if err != nil || len(ips) == 0 {
 			continue
 		}
-		t.AddResult(ip, strings.TrimRight(s, "."))
+		for _, ip := range ips {
+			t.AddResult(ip, strings.TrimRight(s, "."))
+		}
 	}
 	return t
 }

--- a/bsw/srv.go
+++ b/bsw/srv.go
@@ -24,11 +24,13 @@ func SRV(domain, dnsServer string) *Tsk {
 		if err != nil {
 			continue
 		}
-		ip, err := LookupName(srvTarget, dnsServer)
+		ips, err := LookupName(srvTarget, dnsServer)
 		if err != nil {
 			continue
 		}
-		t.AddResult(ip, srvTarget)
+		for _, ip := range ips {
+			t.AddResult(ip, srvTarget)
+		}
 	}
 	return t
 }

--- a/bsw/yandex.go
+++ b/bsw/yandex.go
@@ -44,18 +44,20 @@ func YandexAPI(domain, apiURL, serverAddr string) *Tsk {
 		if domainSet[domain] {
 			return
 		}
-		ip, err := LookupName(domain, serverAddr)
-		if err != nil || ip == "" {
+		ips, err := LookupName(domain, serverAddr)
+		if err != nil || len(ips) == 0 {
 			cfqdn, err := LookupCname(domain, serverAddr)
 			if err != nil || cfqdn == "" {
 				return
 			}
-			ip, err = LookupName(cfqdn, serverAddr)
-			if err != nil || ip == "" {
+			ips, err = LookupName(cfqdn, serverAddr)
+			if err != nil || len(ips) == 0 {
 				return
 			}
 		}
-		t.AddResult(ip, domain)
+		for _, ip := range ips {
+			t.AddResult(ip, domain)
+		}
 	})
 	return t
 }


### PR DESCRIPTION
# Summary

- Modify LookupName*() to return a sorted slice of IPs instead of string
  with the first address record
- Dito for GetWildCard*()
- Rename GetWildCard*() to GetWildcards*()
- Fix typo in bsw/axfr.go around select statement for dns.SRV (ip -> cip)
- Modify Dictionary*() to accept a slice of blacklisted IPs
- Modify main.go to add wildcard IPv4/6 addresses to result
- Attempt to fix things that broke because of the LookupName*() change (many files affected)
- NOTE: Except for the dictionary part I've only compile tested the changes

# Before

- Nothing printed if the zone only contained a wildcard record
- Entire wordlist returned if zone contained a combination of subdomains and a wildcard
- Entire wordlist returned if zone contained a wildcard with multiple addresses
- Only a single IP returned for hostnames that returned more than one address record

Example:

    $ printf "omega8.us\ncloudflare.com\n" > domains.txt
    $ printf "nonexistant\nwww\n" > wordlist.txt
    $ go build && ./blacksheepwall -dictionary wordlist.txt -domain domains.txt
    2017/09/11 09:36:51 Spreading tasks across 100 goroutines
    2017/09/11 09:36:52 All tasks completed
    IP                Hostname              Source
    198.41.214.162    www.cloudflare.com    Dictionary IPv4

# After

- Returns all addresses for a hostname
- Improved handling when wildcard records are found

Example:

    $ printf "omega8.us\ncloudflare.com\n" > domains.txt
    $ printf "nonexistant\nwww\n" > wordlist.txt
    $ go build && ./blacksheepwall -dictionary wordlist.txt -domain domains.txt
    2017/09/11 09:38:15 Spreading tasks across 100 goroutines
    2017/09/11 09:38:15 All tasks completed
    IP                Hostname              Source
    198.41.214.162    www.cloudflare.com    Dictionary IPv4
    198.41.215.162    www.cloudflare.com    Dictionary IPv4
    209.99.40.223     *.omega8.us           Wildcard IPv4